### PR TITLE
feat: Add use-case-driven reporting system

### DIFF
--- a/Application/Abstractions/Interfaces/Services/Report/IReportService.cs
+++ b/Application/Abstractions/Interfaces/Services/Report/IReportService.cs
@@ -1,7 +1,13 @@
-﻿using Entities.Models.Report;
+﻿using Application.DTOs;
+using Entities.Models.Report;
 
 namespace Application.Abstractions.Interfaces.Services;
 
 public interface IReportService : IGenericService<Report>
 {
+    Task<Report> CreateReportAsync(CreateReportDTO dto);
+    Task CloseReportAsync(int reportId);
+    Task<IEnumerable<Report>> GetReportsByEntityAsync(int entityId, int entityTypeId);
+    Task<IEnumerable<Report>> GetReportsByReporterAsync(int reporterId);
+    Task<IEnumerable<Report>> GetOpenReportsAsync();
 }

--- a/Application/DTOs/CreateReportDTO.cs
+++ b/Application/DTOs/CreateReportDTO.cs
@@ -1,0 +1,12 @@
+namespace Application.DTOs;
+
+/// <summary>
+///     DTO for creating a report on an entity (user, post, song, etc.)
+/// </summary>
+public class CreateReportDTO
+{
+    public int EntityIdentifier { get; set; }
+    public int ReportableEntityTypeId { get; set; }
+    public int ReporterId { get; set; }
+    public List<int> ReportReasonTypeIds { get; set; } = new();
+}

--- a/Application/Services/Report/ReportService.cs
+++ b/Application/Services/Report/ReportService.cs
@@ -1,9 +1,80 @@
 ﻿using Application.Abstractions.Interfaces.Repository.Report;
 using Application.Abstractions.Interfaces.Services;
+using Application.DTOs;
+using Application.Exception;
+using Entities.Models.Report;
+using Microsoft.EntityFrameworkCore;
 using ReportModel = Entities.Models.Report.Report;
 
 namespace Application.Services.Report;
 
-public class ReportService(IReportRepository repository) : GenericService<ReportModel>(repository), IReportService
+public class ReportService(
+    IReportRepository repository,
+    IReportReasonTypeRepository reportReasonTypeRepository,
+    IReportableEntityTypeRepository reportableEntityTypeRepository,
+    AppExceptionFactory appExceptionFactory)
+    : GenericService<ReportModel>(repository), IReportService
 {
+    public async Task<ReportModel> CreateReportAsync(CreateReportDTO dto)
+    {
+        // Валидация типа сущности
+        ReportableEntityType? entityType = await reportableEntityTypeRepository.GetByIdAsync(dto.ReportableEntityTypeId);
+        if (entityType == null)
+            throw new NotImplementedException();
+        
+        // Валидация типа причина
+        List<ReportReasonType> reasonTypes = new();
+        foreach (int reasonTypeId in dto.ReportReasonTypeIds)
+        {
+            ReportReasonType? reasonType = await reportReasonTypeRepository.GetByIdAsync(reasonTypeId);
+            if (reasonType == null)
+                throw new NotImplementedException();
+            reasonTypes.Add(reasonType);
+        }
+        
+        ReportModel report = new()
+        {
+            EntityIdentifier = dto.EntityIdentifier,
+            ReportableEntityTypeId = dto.ReportableEntityTypeId,
+            ReporterId = dto.ReporterId,
+            IsClosed = false,
+            ReportReasonType = reasonTypes
+        };
+
+        return await repository.AddAsync(report);
+    }
+
+    public async Task CloseReportAsync(int reportId)
+    {
+        ReportModel? report = await repository.GetByIdAsync(reportId);
+        if (report == null)
+            throw new NotImplementedException();
+
+        report.IsClosed = true;
+        await repository.UpdateAsync(report);
+    }
+
+    public async Task<IEnumerable<ReportModel>> GetReportsByEntityAsync(int entityId, int entityTypeId)
+    {
+        IQueryable<ReportModel> allReports = await repository.GetAllAsync();
+        return await allReports
+            .Where(r => r.EntityIdentifier == entityId && r.ReportableEntityTypeId == entityTypeId)
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<ReportModel>> GetReportsByReporterAsync(int reporterId)
+    {
+        IQueryable<ReportModel> allReports = await repository.GetAllAsync();
+        return await allReports
+            .Where(r => r.ReporterId == reporterId)
+            .ToListAsync();
+    }
+
+    public async Task<IEnumerable<ReportModel>> GetOpenReportsAsync()
+    {
+        IQueryable<ReportModel> allReports = await repository.GetAllAsync();
+        return await allReports
+            .Where(r => !r.IsClosed)
+            .ToListAsync();
+    }
 }

--- a/Sonar/Controllers/Report/ReportController.cs
+++ b/Sonar/Controllers/Report/ReportController.cs
@@ -1,6 +1,7 @@
-using Infrastructure.Data;
+using Application.Abstractions.Interfaces.Services;
+using Application.DTOs;
+using Application.Exception;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace Sonar.Controllers.Report;
 
@@ -8,80 +9,498 @@ namespace Sonar.Controllers.Report;
 [ApiController]
 public class ReportController : ControllerBase
 {
-    private readonly SonarContext _context;
+    private readonly IReportService reportService;
+    private readonly IReportReasonTypeService reportReasonTypeService;
+    private readonly IReportableEntityTypeService reportableEntityTypeService;
+    private readonly AppExceptionFactory appExceptionFactory;
 
-    public ReportController(SonarContext context)
+    public ReportController(
+        IReportService reportService,
+        IReportReasonTypeService reportReasonTypeService,
+        IReportableEntityTypeService reportableEntityTypeService,
+        AppExceptionFactory appExceptionFactory)
     {
-        _context = context;
+        this.reportService = reportService;
+        this.reportReasonTypeService = reportReasonTypeService;
+        this.reportableEntityTypeService = reportableEntityTypeService;
+        this.appExceptionFactory = appExceptionFactory;
     }
 
-    // GET: api/Report
+    #region Report CRUD Endpoints
+
+    /// <summary>
+    ///     Get all reports
+    /// </summary>
+    /// <returns>List of all reports</returns>
     [HttpGet]
     public async Task<ActionResult<IEnumerable<Entities.Models.Report.Report>>> GetReports()
     {
-        return await _context.Reports.ToListAsync();
+        try
+        {
+            IEnumerable<Entities.Models.Report.Report> reports = await reportService.GetAllAsync();
+            return Ok(reports);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
     }
 
-    // GET: api/Report/5
+    /// <summary>
+    ///     Get a specific report by ID
+    /// </summary>
+    /// <param name="id">Report ID</param>
+    /// <returns>Report details</returns>
     [HttpGet("{id}")]
     public async Task<ActionResult<Entities.Models.Report.Report>> GetReport(int id)
     {
-        Entities.Models.Report.Report? report = await _context.Reports.FindAsync(id);
-
-        if (report == null) return NotFound();
-
-        return report;
-    }
-
-    // PUT: api/Report/5
-    // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
-    [HttpPut("{id}")]
-    public async Task<IActionResult> PutReport(int id, Entities.Models.Report.Report report)
-    {
-        if (id != report.Id) return BadRequest();
-
-        _context.Entry(report).State = EntityState.Modified;
-
         try
         {
-            await _context.SaveChangesAsync();
-        }
-        catch (DbUpdateConcurrencyException)
-        {
-            if (!ReportExists(id)) return NotFound();
+            Entities.Models.Report.Report report = await reportService.GetByIdAsync(id);
 
+            if (report == null)
+                throw new NotImplementedException();
+
+            return Ok(report);
+        }
+        catch (AppException)
+        {
             throw;
         }
-
-        return NoContent();
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
     }
 
-    // POST: api/Report
-    // To protect from overposting attacks, see https://go.microsoft.com/fwlink/?linkid=2123754
-    [HttpPost]
-    public async Task<ActionResult<Entities.Models.Report.Report>> PostReport(Entities.Models.Report.Report report)
+    /// <summary>
+    ///     Update a report
+    /// </summary>
+    /// <param name="id">Report ID</param>
+    /// <param name="report">Updated report details</param>
+    /// <returns>Updated report</returns>
+    [HttpPut("{id}")]
+    public async Task<ActionResult<Entities.Models.Report.Report>> PutReport(int id,
+        [FromBody] Entities.Models.Report.Report report)
     {
-        _context.Reports.Add(report);
-        await _context.SaveChangesAsync();
+        try
+        {
+            if (id != report.Id)
+                throw new NotImplementedException();
 
-        return CreatedAtAction("GetReport", new { id = report.Id }, report);
+            Entities.Models.Report.Report updatedReport = await reportService.UpdateAsync(report);
+            return Ok(updatedReport);
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
     }
 
-    // DELETE: api/Report/5
+    /// <summary>
+    ///     Create a new report (direct entity creation - prefer using /create endpoint)
+    /// </summary>
+    /// <param name="report">Report details</param>
+    /// <returns>Created a report</returns>
+    [HttpPost]
+    public async Task<ActionResult<Entities.Models.Report.Report>> PostReport(
+        [FromBody] Entities.Models.Report.Report report)
+    {
+        try
+        {
+            Entities.Models.Report.Report createdReport = await reportService.CreateAsync(report);
+            return CreatedAtAction(nameof(GetReport), new { id = createdReport.Id }, createdReport);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Delete a report
+    /// </summary>
+    /// <param name="id">Report ID</param>
+    /// <returns>No content on success</returns>
     [HttpDelete("{id}")]
     public async Task<IActionResult> DeleteReport(int id)
     {
-        Entities.Models.Report.Report? report = await _context.Reports.FindAsync(id);
-        if (report == null) return NotFound();
-
-        _context.Reports.Remove(report);
-        await _context.SaveChangesAsync();
-
-        return NoContent();
+        try
+        {
+            await reportService.DeleteAsync(id);
+            return NoContent();
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
     }
 
-    private bool ReportExists(int id)
+    #endregion
+
+    #region Business-Specific Report Endpoints
+
+    /// <summary>
+    ///     Create a report for an entity (user, post, song, etc.)
+    /// </summary>
+    /// <param name="dto">Report creation details</param>
+    /// <returns>Created report</returns>
+    [HttpPost("create")]
+    public async Task<ActionResult<Entities.Models.Report.Report>> CreateReport([FromBody] CreateReportDTO dto)
     {
-        return _context.Reports.Any(e => e.Id == id);
+        try
+        {
+            Entities.Models.Report.Report report = await reportService.CreateReportAsync(dto);
+            return CreatedAtAction(nameof(GetReport), new { id = report.Id }, report);
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
     }
+
+    /// <summary>
+    ///     Close/resolve a report (moderator action)
+    /// </summary>
+    /// <param name="id">Report ID</param>
+    /// <returns>No content on success</returns>
+    [HttpPut("{id}/close")]
+    public async Task<IActionResult> CloseReport(int id)
+    {
+        try
+        {
+            await reportService.CloseReportAsync(id);
+            return NoContent();
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Get all reports for a specific entity
+    /// </summary>
+    /// <param name="entityId">Entity identifier</param>
+    /// <param name="typeId">Reportable entity type ID</param>
+    /// <returns>List of reports for the entity</returns>
+    [HttpGet("entity/{entityId}/type/{typeId}")]
+    public async Task<ActionResult<IEnumerable<Entities.Models.Report.Report>>> GetReportsByEntity(int entityId,
+        int typeId)
+    {
+        try
+        {
+            IEnumerable<Entities.Models.Report.Report> reports =
+                await reportService.GetReportsByEntityAsync(entityId, typeId);
+            return Ok(reports);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Get all reports submitted by a specific user
+    /// </summary>
+    /// <param name="reporterId">Reporter user ID</param>
+    /// <returns>List of reports by the user</returns>
+    [HttpGet("reporter/{reporterId}")]
+    public async Task<ActionResult<IEnumerable<Entities.Models.Report.Report>>> GetReportsByReporter(int reporterId)
+    {
+        try
+        {
+            IEnumerable<Entities.Models.Report.Report> reports =
+                await reportService.GetReportsByReporterAsync(reporterId);
+            return Ok(reports);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Get all open/unresolved reports (moderation queue)
+    /// </summary>
+    /// <returns>List of open reports</returns>
+    [HttpGet("open")]
+    public async Task<ActionResult<IEnumerable<Entities.Models.Report.Report>>> GetOpenReports()
+    {
+        try
+        {
+            IEnumerable<Entities.Models.Report.Report> reports = await reportService.GetOpenReportsAsync();
+            return Ok(reports);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    #endregion
+
+    #region Report Reason Type Endpoints
+
+    /// <summary>
+    ///     Get all report reason types
+    /// </summary>
+    /// <returns>List of all reason types</returns>
+    [HttpGet("reason-types")]
+    public async Task<ActionResult<IEnumerable<Entities.Models.Report.ReportReasonType>>> GetReasonTypes()
+    {
+        try
+        {
+            IEnumerable<Entities.Models.Report.ReportReasonType> reasonTypes =
+                await reportReasonTypeService.GetAllAsync();
+            return Ok(reasonTypes);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Get a specific report reason type by ID
+    /// </summary>
+    /// <param name="id">Reason type ID</param>
+    /// <returns>Reason type details</returns>
+    [HttpGet("reason-types/{id}")]
+    public async Task<ActionResult<Entities.Models.Report.ReportReasonType>> GetReasonType(int id)
+    {
+        try
+        {
+            Entities.Models.Report.ReportReasonType reasonType =
+                await reportReasonTypeService.GetByIdAsync(id);
+
+            if (reasonType == null)
+                throw new NotImplementedException();
+
+            return Ok(reasonType);
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Create a new report reason type (admin only)
+    /// </summary>
+    /// <param name="reasonType">Reason type details</param>
+    /// <returns>Created reason type</returns>
+    [HttpPost("reason-types")]
+    public async Task<ActionResult<Entities.Models.Report.ReportReasonType>> CreateReasonType(
+        [FromBody] Entities.Models.Report.ReportReasonType reasonType)
+    {
+        try
+        {
+            Entities.Models.Report.ReportReasonType createdReasonType =
+                await reportReasonTypeService.CreateAsync(reasonType);
+            return CreatedAtAction(nameof(GetReasonType), new { id = createdReasonType.Id }, createdReasonType);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Update a report reason type (admin only)
+    /// </summary>
+    /// <param name="id">Reason type ID</param>
+    /// <param name="reasonType">Updated reason type details</param>
+    /// <returns>Updated reason type</returns>
+    [HttpPut("reason-types/{id}")]
+    public async Task<ActionResult<Entities.Models.Report.ReportReasonType>> UpdateReasonType(int id,
+        [FromBody] Entities.Models.Report.ReportReasonType reasonType)
+    {
+        try
+        {
+            if (id != reasonType.Id)
+                throw new NotImplementedException();
+
+            Entities.Models.Report.ReportReasonType updatedReasonType =
+                await reportReasonTypeService.UpdateAsync(reasonType);
+            return Ok(updatedReasonType);
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Delete a report reason type (admin only)
+    /// </summary>
+    /// <param name="id">Reason type ID</param>
+    /// <returns>No content on success</returns>
+    [HttpDelete("reason-types/{id}")]
+    public async Task<IActionResult> DeleteReasonType(int id)
+    {
+        try
+        {
+            await reportReasonTypeService.DeleteAsync(id);
+            return NoContent();
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    #endregion
+
+    #region Reportable Entity Type Endpoints
+
+    /// <summary>
+    ///     Get all reportable entity types
+    /// </summary>
+    /// <returns>List of all entity types</returns>
+    [HttpGet("entity-types")]
+    public async Task<ActionResult<IEnumerable<Entities.Models.Report.ReportableEntityType>>> GetEntityTypes()
+    {
+        try
+        {
+            IEnumerable<Entities.Models.Report.ReportableEntityType> entityTypes =
+                await reportableEntityTypeService.GetAllAsync();
+            return Ok(entityTypes);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Get a specific reportable entity type by ID
+    /// </summary>
+    /// <param name="id">Entity type ID</param>
+    /// <returns>Entity type details</returns>
+    [HttpGet("entity-types/{id}")]
+    public async Task<ActionResult<Entities.Models.Report.ReportableEntityType>> GetEntityType(int id)
+    {
+        try
+        {
+            Entities.Models.Report.ReportableEntityType entityType =
+                await reportableEntityTypeService.GetByIdAsync(id);
+
+            if (entityType == null)
+                throw new NotImplementedException();
+
+            return Ok(entityType);
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Create a new reportable entity type (admin only)
+    /// </summary>
+    /// <param name="entityType">Entity type details</param>
+    /// <returns>Created entity type</returns>
+    [HttpPost("entity-types")]
+    public async Task<ActionResult<Entities.Models.Report.ReportableEntityType>> CreateEntityType(
+        [FromBody] Entities.Models.Report.ReportableEntityType entityType)
+    {
+        try
+        {
+            Entities.Models.Report.ReportableEntityType createdEntityType =
+                await reportableEntityTypeService.CreateAsync(entityType);
+            return CreatedAtAction(nameof(GetEntityType), new { id = createdEntityType.Id }, createdEntityType);
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Update a reportable entity type (admin only)
+    /// </summary>
+    /// <param name="id">Entity type ID</param>
+    /// <param name="entityType">Updated entity type details</param>
+    /// <returns>Updated entity type</returns>
+    [HttpPut("entity-types/{id}")]
+    public async Task<ActionResult<Entities.Models.Report.ReportableEntityType>> UpdateEntityType(int id,
+        [FromBody] Entities.Models.Report.ReportableEntityType entityType)
+    {
+        try
+        {
+            if (id != entityType.Id)
+                throw new NotImplementedException();
+
+            Entities.Models.Report.ReportableEntityType updatedEntityType =
+                await reportableEntityTypeService.UpdateAsync(entityType);
+            return Ok(updatedEntityType);
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    /// <summary>
+    ///     Delete a reportable entity type (admin only)
+    /// </summary>
+    /// <param name="id">Entity type ID</param>
+    /// <returns>No content on success</returns>
+    [HttpDelete("entity-types/{id}")]
+    public async Task<IActionResult> DeleteEntityType(int id)
+    {
+        try
+        {
+            await reportableEntityTypeService.DeleteAsync(id);
+            return NoContent();
+        }
+        catch (AppException)
+        {
+            throw;
+        }
+        catch (Exception)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
1. Replace direct DbContext dependency in `ReportController` with abstraction-based services.
2. Introduce `CreateReportDTO` for report creation requests.
3. Implement CRUD and business-specific endpoints for managing reports, reason types, and entity types.
4. Add new use-cases: create report, close report, fetch reports by entity, reporter, or open status.
5. Update `IReportService` and `ReportService` to support new reporting flows.